### PR TITLE
#48041: WIP: migrate and refactor price element to price element and …

### DIFF
--- a/components/02-elements/price/Price.stories.js
+++ b/components/02-elements/price/Price.stories.js
@@ -1,0 +1,81 @@
+import { storiesOf } from '@storybook/vue'
+
+import App from '../../01-globals/app/App.vue'
+import AlpacaPrice from './Price.vue'
+import data from './mocks/price.json';
+
+storiesOf('Elements/Price', module)
+  .add('Default', () => ({
+    data() {
+      const priceData = {
+          ...data.variants.special.price
+      };
+      return {
+        price: priceData,
+        ariaLabel: {
+            "old": "Price reduced from: " + priceData.regularPrice.amount.value + priceData.regularPrice.amount.currency,
+            "special": "Sale starts at: " + priceData.specialPrice.amount.value + priceData.specialPrice.amount.currency
+        }
+      }
+    },
+    components: { App, AlpacaPrice },
+    template: `
+      <app>
+        <alpaca-price type="default">
+          {{ price.regularPrice.amount.currencySymbol }} {{ price.regularPrice.amount.value }}
+        </alpaca-price>
+      </app>
+    `
+  }))
+  .add('Special Price', () => ({
+    components: { App, AlpacaPrice },
+    data() {
+      const priceData = {
+          ...data.variants.special.price
+      };
+      return {
+        price: priceData,
+        ariaLabel: {
+            "special": "Sale starts at: " + priceData.specialPrice.amount.value + priceData.specialPrice.amount.currency
+        }
+      }
+    },
+    template: `
+      <app>
+        <alpaca-price
+          type="special"
+        >
+          <ins :aria-label="ariaLabel.special">
+            {{ price.specialPrice.amount.currencySymbol }} {{ price.specialPrice.amount.value }}
+          </ins>
+        </alpaca-price>
+      </app>
+    `
+  }))
+  .add('Old price', () => ({
+    components: { App, AlpacaPrice },
+    data() {
+      const priceData = {
+          ...data.variants.special.price
+      };
+      return {
+        price: priceData,
+        ariaLabel: {
+            "old": "Price reduced from: " + priceData.regularPrice.amount.value + priceData.regularPrice.amount.currency,
+        }
+      }
+    },
+    template: `
+      <app>
+        <alpaca-price
+          type="old"
+        >
+          <del :aria-label="ariaLabel.old">
+            {{ price.regularPrice.amount.currencySymbol }} {{ price.regularPrice.amount.value }}
+          </del>
+        </alpaca-price>
+      </app>
+    `
+  }));
+
+

--- a/components/02-elements/price/Price.vue
+++ b/components/02-elements/price/Price.vue
@@ -1,0 +1,58 @@
+<template>
+  <span
+    class="price"
+    :class="[priceClass, customClass]"
+  >
+    <slot />
+  </span>
+</template>
+
+<script>
+export default {
+  props: {
+    type: {
+      type: String,
+      default: ''
+    },
+    customClass: {
+      type: String,
+      default: null
+    }
+  },
+  data: function() {
+    const priceClasses = {
+        "special": "price--special",
+        "old": "price--old",
+        "regular": ""
+    },
+    type = this.type;
+    return {
+      priceClass: priceClasses[type]
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+
+$price__color              : inherit !default;
+$price__color--special     : $green !default;
+$price__color--old         : inherit !default;
+$price__font-weight        : $font-weight-bold !default;
+$price__font-weight--old   : $font-weight-normal !default;
+$price__font-weight--old   : $font-weight-normal !default;
+
+.price {
+  font-weight: $price__font-weight;
+  &--old {
+    text-decoration: line-through;
+    font-weight: $price__font-weight--old;
+  }
+  &--special {
+    color: $price__color--special;
+    & > ins {
+      text-decoration: none;
+    }
+  }
+}
+</style>

--- a/components/02-elements/price/mocks/price.json
+++ b/components/02-elements/price/mocks/price.json
@@ -1,0 +1,32 @@
+{
+  "variants": {
+    "default": {
+      "price": {
+        "regularPrice": {
+          "amount": {
+            "value": 34,
+            "currency": "USD"
+          }
+        }
+      },
+      "specialPrice": null
+    },
+    "special": {
+      "price": {
+        "regularPrice": {
+          "amount": {
+            "value": 34,
+            "currency": "USD"
+          }
+        },
+        "specialPrice": {
+          "amount": {
+            "value": 34,
+            "currency": "USD"
+          }
+        }
+      },
+      "specialPrice": true
+    }
+  }
+}

--- a/components/03-modules/catalog-grid-item/CatalogGridItem.vue
+++ b/components/03-modules/catalog-grid-item/CatalogGridItem.vue
@@ -20,12 +20,31 @@
       </h2>
 
       <div class="catalog-grid-item__price">
-        $ {{ price }}
+        <alpaca-price-box>
+          <alpaca-price
+            v-if="specialPrice === null"
+            type="default"
+          >
+            $ {{ price }}
+          </alpaca-price>
+          <alpaca-price
+            v-if="specialPrice && price"
+            type="old"
+          >
+            $ {{ price }}
+          </alpaca-price>
+          <alpaca-price
+            v-if="specialPrice"
+            type="special"
+          >
+            $ {{ specialPrice }}
+          </alpaca-price>
+        </alpaca-price-box>
       </div>
 
       <div class="catalog-grid-item__actions">
-        <form 
-          action="#" 
+        <form
+          action="#"
           class="catalog-grid-item__primary-form"
         >
           <alpaca-button
@@ -47,10 +66,14 @@
 
 <script>
 import AlpacaButton from '../../02-elements/button/Button.vue'
+import AlpacaPrice from '../../02-elements/price/Price.vue'
+import AlpacaPriceBox from '../../03-modules/price-box/Price-box.vue'
 
 export default {
   components: {
-    AlpacaButton
+    AlpacaButton,
+    AlpacaPrice,
+    AlpacaPriceBox,
   },
   props: {
     image: {

--- a/components/03-modules/price-box/Price-box.stories.js
+++ b/components/03-modules/price-box/Price-box.stories.js
@@ -1,0 +1,63 @@
+import { storiesOf } from '@storybook/vue'
+
+import App from '../../01-globals/app/App.vue'
+import AlpacaPrice from '../../02-elements/price/Price.vue'
+import AlpacaPriceBox from './Price-box.vue'
+import data from './mocks/price-box.json'
+
+storiesOf('Modules/PriceBox', module)
+  .add('Default', () => ({
+    data() {
+      return {
+        price: {
+            ...data.variants.default.price
+        }
+      }
+    },
+    components: { App, AlpacaPrice, AlpacaPriceBox },
+    template: `
+      <app>
+        <alpaca-price-box>
+            <alpacaPrice type="default">
+              {{ price.regularPrice.amount.currencySymbol }} {{ price.regularPrice.amount.value }}
+            </alpacaPrice>
+        </alpaca-price-box>
+      </app>
+    `
+  }))
+  .add('With Special Price', () => ({
+    data() {
+      const priceData = {
+          ...data.variants.special.price
+      };
+      return {
+        price: priceData,
+        ariaLabel: {
+            "old": "Price reduced from: " + priceData.regularPrice.amount.value + priceData.regularPrice.amount.currency,
+            "special": "Sale starts at: " + priceData.specialPrice.amount.value + priceData.specialPrice.amount.currency
+        }
+      }
+    },
+    components: { App, AlpacaPrice, AlpacaPriceBox },
+    template: `
+      <app>
+        <alpaca-price-box>
+            <alpaca-price
+              type="old"
+            >
+              <del :aria-label="ariaLabel.old">
+                {{ price.regularPrice.amount.currencySymbol }} {{ price.regularPrice.amount.value }}
+              </del>
+            </alpaca-price>
+            
+            <alpaca-price
+              type="special"
+            >
+              <ins :aria-label="ariaLabel.special">
+                {{ price.specialPrice.amount.currencySymbol }} {{ price.specialPrice.amount.value }}
+              </ins>
+            </alpaca-price>
+        </alpaca-price-box>
+      </app>
+    `
+  }));

--- a/components/03-modules/price-box/Price-box.vue
+++ b/components/03-modules/price-box/Price-box.vue
@@ -1,0 +1,33 @@
+<template>
+  <div
+    class="price-box"
+    :class="customClass"
+  >
+    <slot />
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    customClass: {
+      type: String,
+      default: null
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+
+$price__spacing            : $spacer !default;
+
+.price-box {
+  > .price {
+    margin-right: $price__spacing;
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+}
+</style>

--- a/components/03-modules/price-box/mocks/price-box.json
+++ b/components/03-modules/price-box/mocks/price-box.json
@@ -1,0 +1,36 @@
+{
+  "variants": {
+    "default": {
+      "price": {
+        "regularPrice": {
+          "amount": {
+            "value": 3451.21,
+            "currency": "USD",
+            "currencySymbol": "$"
+          }
+        }
+      },
+      "specialPrice": null
+    },
+    "special": {
+      "price": {
+        "regularPrice": {
+          "amount": {
+            "value": 2114.24,
+            "currency": "USD",
+            "currencySymbol": "$"
+          }
+        },
+        "specialPrice": {
+          "amount": {
+            "value": 1999.99,
+            "currency": "USD",
+            "currencySymbol": "$"
+          }
+        }
+      },
+      "specialPrice": true
+    }
+  }
+}
+


### PR DESCRIPTION
WIP: migrating and refactoring price element. 

However as my experience with vue is minimal I'm not sure about about my idea presented it this work in progress PR so waiting for feedback.

1. I think it would be better to split up to single "price" element with different variations like default, special/sale, old/regular as then it's more flexible to build different html structure.
2. Use in price element sth like https://sarahdayan.github.io/dinero.js/ to handle easily different types of showing the price (formatting, currencySymbol ($ at front, zł at the end) or currency (code like USD/PLN), showing FREE (instead of 0 if needed) etc.

3. If required had price-box could/should be refactored still.
